### PR TITLE
Encoding::CompatibilityError

### DIFF
--- a/lib/mime.rb
+++ b/lib/mime.rb
@@ -105,8 +105,11 @@ module Mapi
   		opts = {:boundary_counter => 0}.merge opts
   		if multipart?
   			boundary = Mime.make_boundary opts[:boundary_counter] += 1, self
-  			@body = [preamble, parts.map { |part| "\r\n" + part.to_s(opts) + "\r\n" }, "--\r\n" + epilogue].
-  				flatten.join("\r\n--" + boundary)
+			@body = [
+				preamble,
+				parts.map { |part| "\r\n" + part.to_s(opts).force_encoding('UTF-8') + "\r\n" },
+				"--\r\n" + epilogue
+			].flatten.join("\r\n--" + boundary)
   			content_type, attrs = Mime.split_header @headers['Content-Type'][0]
   			attrs['boundary'] = boundary
   			@headers['Content-Type'] = [([content_type] + attrs.map { |key, val| %{#{key}="#{val}"} }).join('; ')]


### PR DESCRIPTION
Original error message:

```
/Library/Ruby/Gems/2.0.0/gems/ruby-msg-1.5.1/lib/mime.rb:109:in `join': incompatible character encodings: UTF-8 and ASCII-8BIT (Encoding::CompatibilityError)
    from /Library/Ruby/Gems/2.0.0/gems/ruby-msg-1.5.1/lib/mime.rb:109:in `to_s'
    from /Library/Ruby/Gems/2.0.0/gems/ruby-msg-1.5.1/bin/mapitool:104:in `block in process_message'
    from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/open-uri.rb:36:in `open'
    from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/open-uri.rb:36:in `open'
    from /Library/Ruby/Gems/2.0.0/gems/ruby-msg-1.5.1/bin/mapitool:125:in `process_message'
    from /Library/Ruby/Gems/2.0.0/gems/ruby-msg-1.5.1/lib/mapi/msg.rb:344:in `open'
    from /Library/Ruby/Gems/2.0.0/gems/ruby-msg-1.5.1/bin/mapitool:46:in `block in each_message'
    from /Library/Ruby/Gems/2.0.0/gems/ruby-msg-1.5.1/bin/mapitool:30:in `each'
    from /Library/Ruby/Gems/2.0.0/gems/ruby-msg-1.5.1/bin/mapitool:30:in `each_message'
    from /Library/Ruby/Gems/2.0.0/gems/ruby-msg-1.5.1/bin/mapitool:52:in `run'
    from /Library/Ruby/Gems/2.0.0/gems/ruby-msg-1.5.1/bin/mapitool:171:in `mapitool'
    from /Library/Ruby/Gems/2.0.0/gems/ruby-msg-1.5.1/bin/mapitool:174:in `<top (required)>'
    from /usr/bin/mapitool:23:in `load'
    from /usr/bin/mapitool:23:in `<main>'
```

I ran through your how-to in IRB and traced it to line 109 of `lib/mime`

Changing

```
parts.map { |part| "\r\n" + part.to_s(opts) + "\r\n" }
```

to

```
parts.map { |part| "\r\n" + part.to_s(opts).force_encoding('UTF-8') + "\r\n" }
```

seems to have addressed the issue.

I'll attach a pull request to this issue tomorrow morning with my change.
