### PR TITLE
exclude null chars

### DIFF
--- a/lib/mapi/msg.rb
+++ b/lib/mapi/msg.rb
@@ -100,7 +100,7 @@ module Mapi
 			# change these to use mapi symbolic const names
 			ENCODINGS = {
 				0x000d =>   proc { |obj| obj }, # seems to be used when its going to be a directory instead of a file. eg nested ole. 3701 usually. in which case we shouldn't get here right?
-				0x001f =>   proc { |obj| Ole::Types::FROM_UTF16.iconv obj.read }, # unicode
+				0x001f =>   proc { |obj| Ole::Types::Lpwstr.load obj.read }, # unicode
 				# ascii
 				# FIXME hack did a[0..-2] before, seems right sometimes, but for some others it chopped the text. chomp
 				0x001e =>   proc { |obj| obj.read.chomp 0.chr },
@@ -198,7 +198,7 @@ module Mapi
 					prop = if named
 						str_off = str.unpack('V').first
 						len = names_data[str_off, 4].unpack('V').first
-						Ole::Types::FROM_UTF16.iconv names_data[str_off + 4, len]
+						Ole::Types::Lpwstr.load names_data[str_off + 4, len]
 					else
 						a, b = str.unpack('v2')
 						Log.debug "b not 0" if b != 0

--- a/lib/mapi/pst.rb
+++ b/lib/mapi/pst.rb
@@ -1122,7 +1122,7 @@ class Pst
 					if type == PT_STRING8
 						value = value.read
 					elsif type == PT_UNICODE
-						value = Ole::Types::FROM_UTF16.iconv value.read
+						value = Ole::Types::Lpwstr.load value.read
 					end
 				end
 				# special subject handling


### PR DESCRIPTION
Some properties don't exclude NULL chars, for example

current
```
"Content-Type: image/png\r\nContent-Disposition: attachment; filename=\"image.png\u0000\"\r\nContent-Transfer-Encoding: base64\r\nContent-ID: c0568e0d-b0e3-46ec-afb7-4455e98d1878\u0000">
```

expected
```
"Content-Type: image/png\r\nContent-Disposition: attachment; filename=\"image.png\"\r\nContent-Transfer-Encoding: base64\r\nContent-ID: c0568e0d-b0e3-46ec-afb7-4455e98d1878">
```

str = "I\x00P\x00M\x00.\x00N\x00o\x00t\x00e\x00\x00\x00"
Ole::Types::FROM_UTF16.iconv str => "IPM.Note\u0000"
Ole::Types::Lpwstr.load str => "IPM.Note"

This causes a problem for the RubyMail gem, which uses stricter parsing and treats it as an invalid header.