### PR TITLE
Fix NoMethodError in RTF HTML extraction (Ruby 4)

### DIFF
--- a/lib/mapi/rtf.rb
+++ b/lib/mapi/rtf.rb
@@ -235,7 +235,7 @@ module Mapi
 			ignore_tag = nil
 			# skip up to the first htmltag. return nil if we don't ever find one
 			return nil unless scan.scan_until /(?=\{\\\*\\htmltag)/
-			until scan.empty?
+			until scan.eos?
 				if scan.scan /\{/
 				elsif scan.scan /\}/
 				elsif scan.scan /\\\*\\htmltag(\d+) ?/

--- a/ruby-msg.gemspec
+++ b/ruby-msg.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
 	s.files += Dir.glob('test/test_*.rb')
 	s.files += Dir.glob('bin/*')
 
-	s.has_rdoc = true
 	s.extra_rdoc_files = ['README.rdoc', 'ChangeLog']
 	s.rdoc_options += [
 		'--main', 'README.rdoc',


### PR DESCRIPTION
In Ruby 4, `StringScanner#empty?` blows up with `NoMethodError`. This replaces it with `StringScanner#eos?`.

https://docs.ruby-lang.org/en/master/StringScanner.html#method-i-eos-3F

---

Additionally, I've removed one line from the gemspec:

```txt
[!] There was an error while loading `ruby-msg.gemspec`: undefined method 'has_rdoc=' for an instance of Gem::Specification. Bundler cannot continue.

 #  from /Users/visini/.rbenv/versions/4.0.0/lib/ruby/gems/4.0.0/bundler/gems/ruby-msg-dccc7c36f863/ruby-msg.gemspec:25
 #  -------------------------------------------
 #  
 >      s.has_rdoc = true
 #      s.extra_rdoc_files = ['README.rdoc', 'ChangeLog']
 #  -------------------------------------------
``` 